### PR TITLE
New library upload page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <link href="https://fonts.googleapis.com/css?family=Pathway+Gothic+One" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -5,4 +5,4 @@
 @import 'utils.css';
 @import 'landing-page.css';
 @import 'footer.css';
-@import 'tab.css';
+@import 'library.css';

--- a/src/css/library.css
+++ b/src/css/library.css
@@ -1,0 +1,9 @@
+@import './library/music-file.css';
+@import './library/sidebar.css';
+@import './library/tab.css';
+
+#library {
+    display: flex;
+    /* TODO: I have nfi why this doesn't fill the parent's space */
+    height: 100%;
+}

--- a/src/css/library/music-file.css
+++ b/src/css/library/music-file.css
@@ -1,0 +1,22 @@
+#file-view {
+    flex-basis: calc(100% - 224px);    
+    max-width: 1000px; /* This wouldn't exist in the real app */
+    padding: 32px 28px;
+}
+
+.title {
+    display: flex;
+    align-items: center;
+    margin-bottom: 22px;
+}
+
+.title h2 {
+    font-size: 32px;
+    color: #404040;
+}
+
+.title h4 {
+    margin-left: auto;
+    font-size: 22px;
+    color: #404040;
+}

--- a/src/css/library/sidebar.css
+++ b/src/css/library/sidebar.css
@@ -1,0 +1,54 @@
+#sidebar {
+    width: 275px;
+    margin-bottom: 0;
+    padding: 16px 0;
+    background-color: #F2F2F2;
+}
+
+#upload {
+    display: block;
+    margin: 0 auto 14px auto;
+    padding: 8px 20px;
+    
+    font-size: 16px;
+}
+
+#file-tree {
+    font-size: 14px;
+}
+
+/* Handles indenting children */
+/* The way Google Drive handles this issue is to use invisible blocks */
+.folder-container .file-music, .folder-container .folder-container {
+    padding-left: 34px;
+}
+
+/* Styles for each file */
+.file-folder, .file-music {
+    padding: 8px 14px 8px 14px;
+    cursor: pointer;
+}
+
+.file-folder:hover, .file-music:hover {
+    background-color: #E3E3E3;
+}
+
+.fa-folder, .fa-music {
+    margin-right: 15px;
+    font-size: 18px;
+    color: #828282;
+}
+
+.fa-caret-down {
+    margin-right: 12px;
+    font-size: 15px;
+    color: #828282;
+}
+
+.selected {
+    background-color: #E3E3E3;
+}
+
+.selected .fa {
+    color: #07D078;
+}

--- a/src/css/library/tab.css
+++ b/src/css/library/tab.css
@@ -1,12 +1,11 @@
 .tab {
-    margin: auto;
-    max-width: 400px;
     border: 1px solid #333;
-    margin-top: 20px;
+    margin-bottom: 20px;
 }
 
 .tab-header {
     border-bottom: 1px solid #333;
+    padding: 10px 23px;
     display: flex;
     align-items: center;
     flex-grow: 1;
@@ -14,10 +13,14 @@
 
 .tab-title {
     margin-left: 20px;
+    font-size: 16px;
 }
 
-/* Push nav-right items together */
 .tab-download-button {
+    font-size: 18px;
+    color: #07D078;
+    text-decoration: none;
+
     margin-left: auto;
     margin-right: 20px;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import Login from './js/login';
 import Uploader from './js/uploader';
 import ShowTab from './js/show-tab';
 import MyFiles from './js/my_files';
+import Library from './js/components/library.jsx';
 import {clearMsg} from './js/utils/utilities';
 
 import registerServiceWorker from './js/utils/registerServiceWorker.js';
@@ -38,6 +39,7 @@ ReactDOM.render((
                     <Route exact path='/login' component={Login}/>
                     <Route path='/upload' component={Uploader}/>
                     <Route path='/tab' component={ShowTab}/>
+                    <Route path='/library' component={Library}/>
                 </Switch>
             </div>
             <Footer />

--- a/src/js/components/library.jsx
+++ b/src/js/components/library.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import SideBar from './library/sidebar';
+import MusicFile from './library/music-file';
+
+export default class Library extends React.Component {
+    render() {
+        return (
+            <div id="library">
+                <SideBar />
+                <MusicFile />
+            </div>
+        )
+    }
+}

--- a/src/js/components/library/music-container.jsx
+++ b/src/js/components/library/music-container.jsx
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import notes from '../../tabs/example.js';
+import Vex from 'vexflow';
+import VexFlow from '../vexflow';
+
+export default class MusicContainer extends Component {
+    render() {
+        return (
+            <div className='tab'>
+                <div className='tab-header'>
+                    <div className='tab-title'>{this.props.type}</div>
+                    <a href="#" className='tab-download-button'>Download</a>
+                </div>
+                <VexFlow
+                    height={80}
+                    width={300}
+                    font={[ 'Arial', 10, '' ]}
+                    // (x_pos, y_pos, width)
+                    stave={ new Vex.Flow.Stave(0, 0, 300) }
+                    notes={ notes }
+                />
+                <VexFlow
+                    height={80}
+                    width={300}
+                    font={[ 'Arial', 10, '' ]}
+                    // (x_pos, y_pos, width)
+                    stave={ new Vex.Flow.Stave(0, 0, 300) }
+                    notes={ notes }
+                />
+            </div>
+        );
+    }
+}

--- a/src/js/components/library/music-file.jsx
+++ b/src/js/components/library/music-file.jsx
@@ -1,0 +1,17 @@
+import React, { Component } from 'react';
+import MusicContainer from './music-container';
+
+export default class MusicFile extends Component {
+    render() {
+        return (
+            <section id="file-view">
+                <div className="title">
+                    <h2>Mary Had a Little Lamb</h2>
+                    <h4>Sarah Josepha Hale</h4>
+                </div>
+                <MusicContainer type="Tablature" />
+                <MusicContainer type="Traditional" />
+            </section>
+        );
+    }
+}

--- a/src/js/components/library/sidebar.jsx
+++ b/src/js/components/library/sidebar.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import TreeFile from './tree-file';
+import TreeFolder from './tree-folder';
+
+export default class SideBar extends React.Component {
+    render() {
+        return (
+            <section id="sidebar">
+                <button id="upload" className="button">Upload Music</button>
+                <div id="file-tree">
+                    <div className="folder-container">
+                        <TreeFolder title="Pop music 2016" />
+                        <TreeFile title="Closer | Chains..." />
+                        <TreeFile title="Can't Stop the F..." />
+                        <TreeFile title="Panda | Desiigner" />
+                        <div className="folder-container">
+                            <TreeFolder title="End of Year" />
+                            <TreeFile title="Sorry | Ju..." />
+                        </div>
+                    </div>
+                    <TreeFile title="Let the Bodies Hit th..." />
+                    <TreeFile title="Mary Had a Little Lam..." />
+                </div>
+            </section>
+        )
+    }
+}
+
+

--- a/src/js/components/library/tree-file.jsx
+++ b/src/js/components/library/tree-file.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+// Should support adding .selected to one
+
+export default class TreeFile extends React.Component {
+    render() {
+        return (
+            <div className="file-music" ><i className="fa fa-music"></i>{this.props.title}</div>
+        )
+    }
+}

--- a/src/js/components/library/tree-folder.jsx
+++ b/src/js/components/library/tree-folder.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/*
+    Ideally, this would take in a folder object and recursively build it's tree
+*/
+
+export default class TreeFolder extends React.Component {
+    render() {
+        return (
+            <div className="file-folder"><i className="fa fa-caret-down"></i><i className="fa fa-folder"></i>{this.props.title}</div>
+        )
+    }
+}


### PR DESCRIPTION
Creates the new library page that should replace our other existing pages: `/upload` and `/tab`. Currently, this is not entirely complete as the CSS isn't fully defined. 

The page is attached to /library but as mentioned it should ideally replace the above two routes.